### PR TITLE
fix: remove multiple decimals in results

### DIFF
--- a/src/components/Analysis.jsx
+++ b/src/components/Analysis.jsx
@@ -1,10 +1,12 @@
+import { getPercentage, getMaxAmount, getTotalCategory, getDiffAmounts } from '../utils/Calculations'
+
 function Analysis({ title, budget, displayResults }) {
     if (!displayResults || title === 'incomes') return null
     
-    const percentage = title === 'needs' ? 0.5 : title === 'wants' ? 0.3 : 0.2
-    const maxAmount = budget.incomes.reduce((prev, current) => prev + Number(current.amount), 0) * percentage
-    const totalItems = budget[title].reduce((prev, current) => prev + Number(current.amount), 0)
-    const diffAmounts = maxAmount - totalItems
+    const percentage = getPercentage(title)
+    const maxAmount = getMaxAmount(budget.incomes, percentage)
+    const totalItems = getTotalCategory(budget[title])
+    const diffAmounts = getDiffAmounts(maxAmount, totalItems)
 
     return (
         <div className='analysis'>

--- a/src/utils/Calculations.jsx
+++ b/src/utils/Calculations.jsx
@@ -1,0 +1,31 @@
+function getPercentage(title) {
+    let percentage = 0
+    switch (title) {
+        case 'needs':
+            percentage = 0.5
+            break
+        case 'wants':
+            percentage = 0.3
+            break
+        case 'savings':
+            percentage = 0.2
+            break
+    } 
+    return percentage
+}
+
+function getMaxAmount(incomes, percentage) {
+    const maxAmount = incomes.reduce((prev, current) => prev + Number(current.amount), 0) * percentage
+    return (maxAmount * percentage * 100) % 100 !== 0 ? maxAmount.toFixed(1) : maxAmount
+}
+
+function getTotalCategory(category) {
+    return category.reduce((prev, current) => prev + Number(current.amount), 0)
+}
+
+function getDiffAmounts(maxAmount, totalCategory) {
+    const diffAmounts = maxAmount - totalCategory
+    return maxAmount % 1 !== 0 ? diffAmounts.toFixed(1) : diffAmounts
+}
+
+export {getPercentage, getMaxAmount, getTotalCategory, getDiffAmounts}


### PR DESCRIPTION
## Fix issue #30 
## Changes proposed
The max amount and the difference between the max amount and the total per category now displays 0 decimals if they don't have any and only one decimal if they have.
## Screenshots
![image](https://user-images.githubusercontent.com/93607710/201505481-865c3e74-f166-47bc-885a-466636291817.png)
