### PR TITLE
feat: order items per category

### DIFF
--- a/src/components/Category.jsx
+++ b/src/components/Category.jsx
@@ -2,7 +2,9 @@ import LineItem from './LineItem'
 import Analysis from './Analysis'
 
 function Category({ title, budget, displayResults, removeFromBudget, updateModalState }) {
-    const listItems = budget[title].map(item => {
+    const sortedItems = [...budget[title]].sort((a,b) => b.amount - a.amount)
+
+    const listItems = sortedItems.map(item => {
         return <LineItem key={item.id} item={item} removeFromBudget={removeFromBudget} />
     })
 


### PR DESCRIPTION
## Fix issue #31 
## Changes proposed
Items are being ordered by amount from largest to smallest in each category.
